### PR TITLE
add new delete-published-collection-id.js script

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,4 @@ Current tools/scripts
 * [Filter blueprint and output documents include new dataset object](./mongo-fixes/filter-doc-version-identifier)
 * [Instance/version documents include new downloads structure](./mongo-fixes/download-structure/dataset)
 * [Filter output documents include new downloads structure](./mongo-fixes/download-structure/filter)
+* [Remove collection_id from published datasets](./mongo-fixes/delete-published-collection-id)

--- a/mongo-fixes/delete-published-collection-id/README.md
+++ b/mongo-fixes/delete-published-collection-id/README.md
@@ -8,7 +8,7 @@ due to it no longer storing `collection_id` when `{state:"published"}`.
 
 Run
 ```
-mongo <mongo_url> delete-published-collection-id.js
+mongo <mongo_url> <options> delete-published-collection-id.js
 ```
 
 The `<mongo_url>` part should look like:
@@ -17,3 +17,15 @@ The `<mongo_url>` part should look like:
     `mongodb://<username>:<password>@<host>:<port>/datasets?authSource=admin`
     (use single-quotes for protection from your shell)
 - in the above, `/datasets` indicates the database to be modified
+
+Example of the (optional) `<options>` part:
+
+- `--eval 'cfg={verbose:true}'` (e.g. use for debugging)
+- `cfg` defaults to: `{verbose:true, ids:true, update: true}`
+- if you specify `cfg`, all missing options default to `false`
+
+Full example (e.g. for capturing IDs and not wiping them):
+
+```
+mongo localhost:27017/datasets --eval 'cfg={verbose:true, ids:true}' delete-published-collection-id.js
+```

--- a/mongo-fixes/delete-published-collection-id/README.md
+++ b/mongo-fixes/delete-published-collection-id/README.md
@@ -1,0 +1,19 @@
+delete-published-collection-id
+==================
+
+This utility updates `dataset` resources on CMD
+due to it no longer storing `collection_id` when `{state:"published"}`.
+
+### How to run the utility
+
+Run
+```
+mongo <mongo_url> delete-published-collection-id.js
+```
+
+The `<mongo_url>` part should look like:
+- `localhost:27017/datasets` or `127.0.0.1:27017/datasets`
+  - if authentication is needed, use:
+    `mongodb://<username>:<password>@<host>:<port>/datasets?authSource=admin`
+    (use single-quotes for protection from your shell)
+- in the above, `/datasets` indicates the database to be modified

--- a/mongo-fixes/delete-published-collection-id/delete-published-collection-id.js
+++ b/mongo-fixes/delete-published-collection-id/delete-published-collection-id.js
@@ -1,0 +1,73 @@
+// delete-published-collection-id.js
+//
+// if a dataset doc has:
+//     next.state:"published" and non-blank    next.collection_id ---> delete latter
+//  current.state:"published" and non-blank current.collection_id ---> delete latter
+
+// collection
+ds_collection = 'datasets'
+
+// sub-document parts
+ds_subdocs = ['next', 'current']
+
+// do a find first, show what would be changed
+show_find         = true
+// if show_find is true, show_old_ids_only limits output to collection_id
+show_old_ids_only = true
+
+// o determines what find() outputs (null shows all)
+o = null
+
+// set to false to only use show_find
+do_update = true
+
+//////////////////////////
+
+// utility to printjson(r) even if r is a cursor (iterate over it)
+function show_(r){
+        if (r==null) { print(''); return; }
+        if (r.hasNext != undefined) {
+                while (r.hasNext()) {
+                        printjson(r.next())
+                }
+        } else {
+                printjson(r)
+        }
+}
+
+//////////////////////////
+
+for (i = 0; i < ds_subdocs.length; i++) {
+        // build paths for this sub-doc
+        state_path  = ds_subdocs[i] + '.state'
+        collid_path = ds_subdocs[i] + '.collection_id'
+
+        // build the modifier: {$unset:{sub_doc.collection_id:""}
+        setter_cid              = {}
+        setter_cid[collid_path] = ""
+        setter                  = {"$unset":setter_cid}
+
+        // build the filter query
+        q = {}
+        q[state_path]  = "published"
+        q[collid_path] = {"$exists":true,"$ne":''}
+
+        show_(
+                'collection:' + ds_collection + ' sub-doc:' + ds_subdocs[i] +
+                ' state@' + state_path + ' c_id@' + collid_path
+        )
+
+        if (show_find) {
+                if (show_old_ids_only) {
+                        o = {}
+                        o[collid_path] = 1
+                }
+                r = db.getCollection(ds_collection).find(q, o)
+                show_(r)
+        }
+
+        if (do_update) {
+                r = db.getCollection(ds_collection).updateMany(q, setter)
+                show_(r)
+        }
+}

--- a/mongo-fixes/delete-published-collection-id/delete-published-collection-id.js
+++ b/mongo-fixes/delete-published-collection-id/delete-published-collection-id.js
@@ -10,16 +10,18 @@ ds_collection = 'datasets'
 // sub-document parts
 ds_subdocs = ['next', 'current']
 
-// do a find first, show what would be changed
-show_find         = true
-// if show_find is true, show_old_ids_only limits output to collection_id
-show_old_ids_only = true
+if (typeof(cfg) == "undefined") {
+        // default, but can be changed on command-line, see README
+        cfg = {
+                verbose:  true,    // do a find first, show what would be changed
+                ids:      true,    // if verbose is true, ids limits output to collection_id
+                update:   true     // set to false to avoid updates
+        }
+}
 
 // o determines what find() outputs (null shows all)
 o = null
 
-// set to false to only use show_find
-do_update = true
 
 //////////////////////////
 
@@ -57,8 +59,8 @@ for (i = 0; i < ds_subdocs.length; i++) {
                 ' state@' + state_path + ' c_id@' + collid_path
         )
 
-        if (show_find) {
-                if (show_old_ids_only) {
+        if (cfg.verbose) {
+                if (cfg.ids) {
                         o = {}
                         o[collid_path] = 1
                 }
@@ -66,7 +68,7 @@ for (i = 0; i < ds_subdocs.length; i++) {
                 show_(r)
         }
 
-        if (do_update) {
+        if (cfg.update) {
                 r = db.getCollection(ds_collection).updateMany(q, setter)
                 show_(r)
         }


### PR DESCRIPTION
a departure from the other scripts (hence the repo name change) to using mongo shell (javascript) for this update to the database

delete `current.collection_id` and `next.collection_id` if that dataset sub-doc has `state:published`