### PR TITLE
Deeper comparison needed due to someone changing a struct order

### DIFF
--- a/audit-tools/ons-audit-uri/main.go
+++ b/audit-tools/ons-audit-uri/main.go
@@ -2311,7 +2311,7 @@ func getPageData(shortURI string, fieldName string, parentURI string, index int,
 		}
 
 		payload, err := json.Marshal(data)
-		checkMarshaling(fullURI, err, 9, &payload, &fixedJSON, "datasetLandingPageResponse")
+		checkMarshalingDeepEqual(fullURI, err, 9, &payload, &fixedJSON, "datasetLandingPageResponse")
 
 		saveContentPageToCollection(datasetLandingPageJsFile, &datasetLandingPageCount, datasetLandingPageCollectionName, bodyTextCopy, shortURI)
 		if cfg.FullDepth {
@@ -2326,7 +2326,7 @@ func getPageData(shortURI string, fieldName string, parentURI string, index int,
 		}
 
 		payload, err := json.Marshal(data)
-		checkMarshaling(fullURI, err, 10, &payload, &fixedJSON, "datasetLandingPageResponse")
+		checkMarshaling(fullURI, err, 10, &payload, &fixedJSON, "staticMethodologyResponse")
 
 		saveContentPageToCollection(staticMethodologyJsFile, &staticMethodologyCount, staticMethodologyCollectionName, bodyTextCopy, shortURI)
 		if cfg.FullDepth {


### PR DESCRIPTION
1. cDescription struct has had the ordering of ‘metaCmd’ and ‘sampleSize’ swapped elsewhere in ONS code, so had to use a deeper comparison method for page type datasetLandingPageResponse.
2. Fix wrong description of page type being processed.

Just a visual inspection will do for review.