### PR TITLE
Id data migration user_group file now uses UUID

### DIFF
--- a/dp-identity-data-migration/groupsdataextraction/group_extraction.go
+++ b/dp-identity-data-migration/groupsdataextraction/group_extraction.go
@@ -80,21 +80,21 @@ func ExtractGroupsData() {
 	}
 
 	tmpUserGroups := make(map[string][]string)
-	for k := range users {
-		_, isKeyPresent := tmpUserGroups[k]
+	for userEmail, userUUID := range users {
+		_, isKeyPresent := tmpUserGroups[userEmail]
 		if !isKeyPresent {
-			tmpUserGroups[k] = make([]string, 0)
+			tmpUserGroups[userUUID] = make([]string, 0)
 		}
-		permissions, err := zebCli.GetPermissions(sess, k)
+		permissions, err := zebCli.GetPermissions(sess, userEmail)
 		if err != nil {
 			log.Println(err)
 		}
 		if permissions.Admin {
-			tmpUserGroups[k] = append(tmpUserGroups[k], "role-admin")
+			tmpUserGroups[userUUID] = append(tmpUserGroups[userUUID], "role-admin")
 		}
 
 		if permissions.Editor {
-			tmpUserGroups[k] = append(tmpUserGroups[k], "role-publisher")
+			tmpUserGroups[userUUID] = append(tmpUserGroups[userUUID], "role-publisher")
 		}
 	}
 


### PR DESCRIPTION
Change the zebedee user migration script to make the users-groups mapping file use generated UUIDs from the user extraction process instead of the user's email address. This matches the backup process so the import script will work.