### PR TITLE
Fix identit user extract script to use lowercase for bools

### DIFF
--- a/dp-identity-data-migration/userdataextraction/user_extraction.go
+++ b/dp-identity-data-migration/userdataextraction/user_extraction.go
@@ -177,10 +177,10 @@ func processZebedeeUsers(validUsersWriter *csv.Writer, invalidUsersWriter *csv.W
 			csvLine.familyName = names[0]
 		}
 
-		csvLine.mfaEnabled = "FALSE"
-		csvLine.enabled = "TRUE"
-		csvLine.phoneNumberVerified = "FALSE"
-		csvLine.emailVerified = "TRUE"
+		csvLine.mfaEnabled = "false"
+		csvLine.enabled = "true"
+		csvLine.phoneNumberVerified = "false"
+		csvLine.emailVerified = "true"
 
 		userDetails := convertToSlice(csvLine)
 		if validateEmailId(validEmailDomains, user.Email) {


### PR DESCRIPTION
Fix identity user extract script to use lowercase for bools to match the format used for the import as per the backup files